### PR TITLE
Fixes no tile for cell when margin/spacing 0 

### DIFF
--- a/src/tile-set.js
+++ b/src/tile-set.js
@@ -123,8 +123,8 @@ define(["jquery", "./tile", "./util/util"], function ($, Tile, Util) {
             tileSet.tileInfo = {
                 w: parseInt(e.attr("tilewidth")) || 1,
                 h: parseInt(e.attr("tileheight")) || 1,
-                spacing: parseInt(e.attr("spacing")),
-                margin: parseInt(e.attr("margin"))
+                spacing: parseInt(e.attr("spacing")) || 0,
+                margin: parseInt(e.attr("margin")) || 0
             };
 
             var image = e.children("image:first");


### PR DESCRIPTION
previously if info not available margin and spacing parse to NaN and break the loop for generating tiles. Tiled doesn't add margin/spacing property to the tmx file when they are 0
